### PR TITLE
change in os

### DIFF
--- a/.github/workflows/copybara-os.sky.template
+++ b/.github/workflows/copybara-os.sky.template
@@ -39,6 +39,21 @@ core.workflow(
     ] + PUSH_TRANSFORMATIONS if PUSH_TRANSFORMATIONS else core.reverse(PR_TRANSFORMATIONS),
 )
 
+def add_comment_with_shadow_pr():
+    """After migration action that notifies in GitHub PRs the status of the import."""
+    return core.dynamic_feedback(
+        impl = _add_comment_with_shadow_pr_impl,
+        params = {},
+    )
+
+def _add_comment_with_shadow_pr_impl(ctx):
+   ctx.console.info("Updating original PR description with info about internal PR")
+   pr_number = ctx.revision.labels["GITHUB_PR_NUMBER"][0]
+   for effect in ctx.effects:
+       if effect.type == "CREATED":
+              original_pr_name=SOT_REPO.replace("git@github.com:", " ").replace(".git", "#" + pr_number)
+              ctx.origin.post_issue_comment(int(pr_number), "Closes " + original_pr_name)
+
 # Pull Request workflow
 core.workflow(
     name = "pr",
@@ -63,4 +78,5 @@ core.workflow(
         metadata.expose_label("GITHUB_PR_NUMBER", new_name = "Closes", separator = DESTINATION_REPO.replace("git@github.com:", " ").replace(".git", "#")),
         metadata.save_author("ORIGINAL_AUTHOR"),
     ] + PR_TRANSFORMATIONS,
+    after_workflow = [add_comment_with_shadow_pr()],
 )

--- a/.github/workflows/copybara-os.yaml
+++ b/.github/workflows/copybara-os.yaml
@@ -64,7 +64,8 @@ jobs:
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
           PR_BODY='${{ github.event.pull_request.body }}'
-          
+          PR_BODY+=$(gh pr view PR_NUMBER --json comments -q '.comments[].body')
+
           while read -r line; do
             if [[ $line =~ ^Closes\ ([^/]+)/([^/]+)#([0-9]+) ]]; then
               OWNER="${BASH_REMATCH[1]}"

--- a/os.txt
+++ b/os.txt
@@ -1,0 +1,1 @@
+change 1 in os


### PR DESCRIPTION
Description of the change in pr-9

INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
